### PR TITLE
Closing all connection after request is complete.

### DIFF
--- a/src/com/wb/nextgenlibrary/NextGenExperience.java
+++ b/src/com/wb/nextgenlibrary/NextGenExperience.java
@@ -136,8 +136,11 @@ public class NextGenExperience {
 				"/xml/urn:dece:cid:eidr-s:FE5F-6323-6DBC-F158-0387-M/wardogs_manifest-1.0.xml",
 				"/xml/urn:dece:cid:eidr-s:FE5F-6323-6DBC-F158-0387-M/wardogs_appdata-1.0.xml",
 				"/xml/urn:dece:cid:eidr-s:FE5F-6323-6DBC-F158-0387-M/wardogs_cpestyle-1.0.xml"));
-
-
+		manifestItems.add(new ManifestItem("Suicide squad", "urn:dece:cid:eidr-s:41D1-41F1-B266-14D0-416F-9",
+				null,
+				"/xml/urn:dece:cid:eidr-s:41D1-41F1-B266-14D0-416F-9/suicidesquad_manifest-1.0.xml",
+				"/xml/urn:dece:cid:eidr-s:41D1-41F1-B266-14D0-416F-9/suicidesquad_appdata-1.0.xml",
+				"/xml/urn:dece:cid:eidr-s:41D1-41F1-B266-14D0-416F-9/suicidesquad_cpestyle-1.0.xml"));
 
     }
 

--- a/src/com/wb/nextgenlibrary/fragment/NextGenActorDetailFragment.java
+++ b/src/com/wb/nextgenlibrary/fragment/NextGenActorDetailFragment.java
@@ -38,8 +38,6 @@ import com.wb.nextgenlibrary.widget.FixedAspectRatioFrameLayout;
 
 import java.util.List;
 
-import static com.google.android.gms.analytics.internal.zzy.r;
-
 /**
  * Created by gzcheng on 1/13/16.
  */

--- a/src/com/wb/nextgenlibrary/util/HttpHelper.java
+++ b/src/com/wb/nextgenlibrary/util/HttpHelper.java
@@ -35,12 +35,18 @@ import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.conn.ConnectionReleaseTrigger;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HTTP;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
 
 
@@ -322,10 +328,11 @@ public class HttpHelper {
 	public static String getFromUrl(String url, List <NameValuePair> params, List <NameValuePair> headerValues) throws IOException {
 		NextGenLogger.d(F.TAG_API, "HttpHelper.getFromUrl url:" + url);
 		InputStream content = null;
+		HttpClient httpClient = null;
 		try {
-			HttpClient httpClient = isSecureFlxUrl(url) ? new SecureFlxHttpClient()
+			httpClient = isSecureFlxUrl(url) ? new SecureFlxHttpClient()
 					: new DefaultHttpClient();
-			
+
 			HttpParams clientParameters = httpClient.getParams();
 			HttpConnectionParams.setConnectionTimeout(clientParameters, TIMEOUT_CONNECTION);
 			HttpConnectionParams.setSoTimeout(clientParameters, TIMEOUT_HTTP_POST);
@@ -373,6 +380,9 @@ public class HttpHelper {
 				} catch (IOException e) {
 					/* Ignored */
 				}
+			}
+			if (httpClient != null) {
+				httpClient.getConnectionManager().shutdown();
 			}
 		}
 	}


### PR DESCRIPTION
HttpClient was designed to have one single instance across the app, this way the connections can be optimized internally using keep-alive header. But a single instance is not used here. So after each request, app should shutdown HttpClient to release all internal connections.